### PR TITLE
Add Dockerfile for Ubuntu 20.04

### DIFF
--- a/deploy/neonsan/docker/ubuntu/2004.Dockerfile
+++ b/deploy/neonsan/docker/ubuntu/2004.Dockerfile
@@ -1,0 +1,32 @@
+# +-------------------------------------------------------------------------
+# | Copyright (C) 2018 Yunify, Inc.
+# +-------------------------------------------------------------------------
+# | Licensed under the Apache License, Version 2.0 (the "License");
+# | you may not use this work except in compliance with the License.
+# | You may obtain a copy of the License in the LICENSE file, or at:
+# |
+# | http://www.apache.org/licenses/LICENSE-2.0
+# |
+# | Unless required by applicable law or agreed to in writing, software
+# | distributed under the License is distributed on an "AS IS" BASIS,
+# | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# | See the License for the specific language governing permissions and
+# | limitations under the License.
+# +-------------------------------------------------------------------------
+
+FROM golang:1.14.4-alpine as builder
+WORKDIR /qingstor-csi
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -mod=vendor  -ldflags "-s -w" -o  _output/neonsan-csi-driver ./cmd/neonsan
+
+FROM ubuntu:20.04
+LABEL maintainers="Yunify"
+LABEL description="NeonSAN CSI plugin"
+# libcurl4 and libicu60 for qbd
+RUN apt-get update -y && \
+    apt-get install -y libcurl4 libicu66 && \
+    apt-get install -y e2fsprogs xfsprogs mount ca-certificates udev
+COPY --from=builder /qingstor-csi/_output/neonsan-csi-driver /neonsan-csi-driver
+RUN chmod +x /neonsan-csi-driver && \
+    mkdir -p /var/log/neonsan-csi-driver
+ENTRYPOINT ["/neonsan-csi-driver"]


### PR DESCRIPTION
Signed-off-by: dkeven <keven@kubesphere.io>

Fixes https://github.com/yunify/qingstor-csi/issues/55

Notice that if using a DKMS enabled QBD package, the OS version of the image of the `csi-neonsan-controller` does not matter. 